### PR TITLE
Fix: Restore cursor position after formatting upon saving the buffer.

### DIFF
--- a/ftplugin/haskell/stylishask.vim
+++ b/ftplugin/haskell/stylishask.vim
@@ -51,6 +51,7 @@ function! stylishask#StylishaskOnSave()
     if g:stylishask_on_save == 1
         let b:winview = winsaveview()
         exe "%call stylishask#Stylishask()"
+        call winrestview(b:winview)
     endif
 endfunction
 


### PR DESCRIPTION
Relevant issue: https://github.com/alx741/vim-stylishask/issues/3

Fix details: Add `winrestview` in the "format upon save" function just like in the range (manual) formatting function. Tested on local system - works as expected.